### PR TITLE
Fixed instructions for Part 2 in Exercise 02

### DIFF
--- a/docs/02_implement_multimodal_ai_shopping_assistant/02_02.md
+++ b/docs/02_implement_multimodal_ai_shopping_assistant/02_02.md
@@ -485,9 +485,9 @@ from agent_initializer import initialize_agent
 
 load_dotenv()
 
-CORA_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'ShopperAgentPrompt.txt')
-with open(CORA_PROMPT_TARGET, 'r', encoding='utf-8') as file:
-    CORA_PROMPT = file.read()
+CM_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'CartManagerPrompt.txt')
+with open(CM_PROMPT_TARGET, 'r', encoding='utf-8') as file:
+    CM_PROMPT = file.read()
 
 project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
 
@@ -496,8 +496,8 @@ project_client = AIProjectClient(
     credential=DefaultAzureCredential(),
 )
 
-# Create function tools for cora agent
-functions = create_function_tool_for_agent("cora")
+# Create function tools for Cart Manager agent
+functions = create_function_tool_for_agent("cart_manager")
 toolset = ToolSet()
 toolset.add(functions)
 project_client.agents.enable_auto_function_calls(tools=functions)
@@ -505,9 +505,9 @@ project_client.agents.enable_auto_function_calls(tools=functions)
 initialize_agent(
     project_client=project_client,
     model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
-    env_var_name="cora",
-    name="Cora - Zava Shopping Assistant",
-    instructions=CORA_PROMPT,
+    env_var_name="cart_manager",
+    name="Zava Cart Manager",
+    instructions=CM_PROMPT,
     toolset=toolset
 )
 ```


### PR DESCRIPTION
The instructions for Part 2 of Exercise 2 are incorrect; the code for the cartManagerAgent_initializer.py is copied and pasted from the previous example.  This pull request updates it to be correct for the cart_manager references in several places.