### PR TITLE
Implement multi-agent architecture with handoff service

### DIFF
--- a/src/app/agents/cartManagerAgent_initializer.py
+++ b/src/app/agents/cartManagerAgent_initializer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ToolSet
+from dotenv import load_dotenv
+from agent_processor import create_function_tool_for_agent
+from agent_initializer import initialize_agent
+
+load_dotenv()
+
+CART_PROMPT_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'CartManagerPrompt.txt')
+with open(CART_PROMPT_PATH, 'r', encoding='utf-8') as file:
+    CART_MANAGER_PROMPT = file.read()
+
+project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
+
+project_client = AIProjectClient(
+    endpoint=project_endpoint,
+    credential=DefaultAzureCredential(),
+)
+
+# Create function tools for cart_manager agent
+functions = create_function_tool_for_agent("cart_manager")
+toolset = ToolSet()
+toolset.add(functions)
+project_client.agents.enable_auto_function_calls(tools=functions)
+
+initialize_agent(
+    project_client=project_client,
+    model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
+    env_var_name="cart_manager",
+    name="Zava Cart Manager Agent",
+    instructions=CART_MANAGER_PROMPT,
+    toolset=toolset
+)

--- a/src/app/agents/customerLoyaltyAgent_initializer.py
+++ b/src/app/agents/customerLoyaltyAgent_initializer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ToolSet
+from dotenv import load_dotenv
+from agent_processor import create_function_tool_for_agent
+from agent_initializer import initialize_agent
+
+load_dotenv()
+
+CL_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'CustomerLoyaltyAgentPrompt.txt')
+with open(CL_PROMPT_TARGET, 'r', encoding='utf-8') as file:
+    CL_PROMPT = file.read()
+
+project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
+
+project_client = AIProjectClient(
+    endpoint=project_endpoint,
+    credential=DefaultAzureCredential(),
+)
+
+# Define the set of user-defined callable functions to use as tools (from MCP client)
+functions = create_function_tool_for_agent("customer_loyalty")
+toolset = ToolSet()
+toolset.add(functions)
+project_client.agents.enable_auto_function_calls(tools=functions)
+
+initialize_agent(
+    project_client=project_client,
+    model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
+    env_var_name="customer_loyalty",
+    name="Zava Customer Loyalty Agent",
+    instructions=CL_PROMPT,
+    toolset=toolset
+)

--- a/src/app/agents/interiorDesignAgent_initializer.py
+++ b/src/app/agents/interiorDesignAgent_initializer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ToolSet
+from dotenv import load_dotenv
+from agent_processor import create_function_tool_for_agent
+from agent_initializer import initialize_agent
+
+load_dotenv()
+
+ID_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'InteriorDesignAgentPrompt.txt')
+with open(ID_PROMPT_TARGET, 'r', encoding='utf-8') as file:
+    ID_PROMPT = file.read()
+
+project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
+
+project_client = AIProjectClient(
+    endpoint=project_endpoint,
+    credential=DefaultAzureCredential(),
+)
+
+# Define the set of user-defined callable functions to use as tools (from MCP client)
+functions = create_function_tool_for_agent("interior_designer")
+toolset = ToolSet()
+toolset.add(functions)
+project_client.agents.enable_auto_function_calls(tools=functions)
+
+initialize_agent(
+    project_client=project_client,
+    model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
+    env_var_name="interior_designer",
+    name="Zava Interior Design Agent",
+    instructions=ID_PROMPT,
+    toolset=toolset
+)

--- a/src/app/agents/inventoryAgent_initializer.py
+++ b/src/app/agents/inventoryAgent_initializer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ToolSet
+from dotenv import load_dotenv
+from agent_processor import create_function_tool_for_agent
+from agent_initializer import initialize_agent
+
+load_dotenv()
+
+IA_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'InventoryAgentPrompt.txt')
+with open(IA_PROMPT_TARGET, 'r', encoding='utf-8') as file:
+    IA_PROMPT = file.read()
+
+project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
+
+project_client = AIProjectClient(
+    endpoint=project_endpoint,
+    credential=DefaultAzureCredential(),
+)
+
+# Define the set of user-defined callable functions to use as tools (from MCP client)
+functions = create_function_tool_for_agent("customer_loyalty")
+toolset = ToolSet()
+toolset.add(functions)
+project_client.agents.enable_auto_function_calls(tools=functions)
+
+initialize_agent(
+    project_client=project_client,
+    model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
+    env_var_name="inventory_agent",
+    name="Zava Inventory Agent",
+    instructions=IA_PROMPT,
+    toolset=toolset
+)

--- a/src/app/agents/shopperAgent_initializer.py
+++ b/src/app/agents/shopperAgent_initializer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from azure.ai.agents.models import ToolSet
+from dotenv import load_dotenv
+from agent_processor import create_function_tool_for_agent
+from agent_initializer import initialize_agent
+
+load_dotenv()
+
+CORA_PROMPT_TARGET = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'prompts', 'ShopperAgentPrompt.txt')
+with open(CORA_PROMPT_TARGET, 'r', encoding='utf-8') as file:
+    CORA_PROMPT = file.read()
+
+project_endpoint = os.environ["AZURE_AI_AGENT_ENDPOINT"]
+
+project_client = AIProjectClient(
+    endpoint=project_endpoint,
+    credential=DefaultAzureCredential(),
+)
+
+# Create function tools for cora agent
+functions = create_function_tool_for_agent("cora")
+toolset = ToolSet()
+toolset.add(functions)
+project_client.agents.enable_auto_function_calls(tools=functions)
+
+initialize_agent(
+    project_client=project_client,
+    model=os.environ["AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"],
+    env_var_name="cora",
+    name="Cora - Zava Shopping Assistant",
+    instructions=CORA_PROMPT,
+    toolset=toolset
+)

--- a/src/app/tools/singleAgentExample.py
+++ b/src/app/tools/singleAgentExample.py
@@ -1,0 +1,66 @@
+import os
+import base64
+from openai import AzureOpenAI
+from dotenv import load_dotenv
+import numpy as np
+import time
+
+# Load environment variables (Azure endpoint, deployment, keys, etc.)
+load_dotenv()
+
+# Retrieve credentials from .env file or environment
+endpoint = os.getenv("gpt_endpoint")
+deployment = os.getenv("gpt_deployment")
+api_key = os.getenv("gpt_api_key")
+api_version = os.getenv("gpt_api_version")
+
+# Initialize Azure OpenAI client for GPT model
+client = AzureOpenAI(
+    azure_endpoint=endpoint,
+    api_key=api_key,
+    api_version=api_version,
+)
+
+def generate_response(text_input):
+    start_time = time.time()
+    """
+    Input:
+        text_input (str): The user's chat input.
+
+    Output:
+        response (str): A Markdown-formatted response from the agent.
+    """
+
+    # Prepare the full chat prompt with system and user messages
+    chat_prompt = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": """You are a helpful assistant working for Zava, a company that specializes in offering products to assist homeowners with do-it-yourself projects.
+                        Respond to customer inquiries with relevant product recommendations and DIY tips. If a customer asks for paint, suggest one of the following three colors: blue, green, and white.
+                        If a customer asks for something not related to a DIY project, politely inform them that you can only assist with DIY-related inquiries.
+                        Zava has a variety of store locations across the country. If a customer asks about store availability, direct the customer to the Miami store.
+                    """
+                }
+            ]
+        },
+        {"role": "user", "content": text_input}
+    ]
+
+    # Call Azure OpenAI chat API
+    completion = client.chat.completions.create(
+        model=deployment,
+        messages=chat_prompt,
+        max_completion_tokens=10000,
+        top_p=1,
+        frequency_penalty=0,
+        presence_penalty=0,
+        stop=None,
+        stream=False
+    )
+    end_sum = time.time()
+    print(f"generate_response Execution Time: {end_sum - start_time} seconds")
+    # Return response content
+    return completion.choices[0].message.content

--- a/src/chat_app.py
+++ b/src/chat_app.py
@@ -43,10 +43,10 @@ from utils.message_utils import (
 from app.tools.understandImage import get_image_description
 from services.agent_service import get_or_create_agent_processor
 # from app.tools.singleAgentExample import generate_response
-# from app.tools.aiSearchTools import product_recommendations
-# from app.tools.imageCreationTool import create_image
-# from app.servers.mcp_inventory_server import mcp as inventory_mcp
-# from services.handoff_service import HandoffService
+from app.tools.aiSearchTools import product_recommendations
+from app.tools.imageCreationTool import create_image
+from app.servers.mcp_inventory_server import mcp as inventory_mcp
+from services.handoff_service import HandoffService
 
 
 load_dotenv()
@@ -114,8 +114,8 @@ async def safe_operation(operation, fallback_value=None, operation_name="Unknown
 
 app = FastAPI()
 #set up MCP inventory server as a mounted app
-# inventory_mcp_app = inventory_mcp.sse_app()
-# app.mount("/mcp-inventory/", inventory_mcp_app)
+inventory_mcp_app = inventory_mcp.sse_app()
+app.mount("/mcp-inventory/", inventory_mcp_app)
 project_endpoint = os.environ.get("AZURE_AI_AGENT_ENDPOINT")
 if not project_endpoint:
     raise ValueError("AZURE_AI_AGENT_ENDPOINT environment variable is required")
@@ -124,18 +124,18 @@ project_client = AIProjectClient(
     credential=DefaultAzureCredential(),
 )
 
-# llm_client = AzureOpenAI(
-#     azure_endpoint=validated_env_vars['AZURE_OPENAI_ENDPOINT'],
-#     api_key=validated_env_vars['AZURE_OPENAI_KEY'],
-#     api_version=validated_env_vars['AZURE_OPENAI_API_VERSION'],
-# )
+llm_client = AzureOpenAI(
+    azure_endpoint=validated_env_vars['AZURE_OPENAI_ENDPOINT'],
+    api_key=validated_env_vars['AZURE_OPENAI_KEY'],
+    api_version=validated_env_vars['AZURE_OPENAI_API_VERSION'],
+)
 
-# handoff_service = HandoffService(
-#     azure_openai_client=llm_client,
-#     deployment_name=validated_env_vars['gpt_deployment'],
-#     default_domain="cora",
-#     lazy_classification=True
-# )
+handoff_service = HandoffService(
+    azure_openai_client=llm_client,
+    deployment_name=validated_env_vars['gpt_deployment'],
+    default_domain="cora",
+    lazy_classification=True
+)
 
 @app.get("/")
 async def get():
@@ -245,7 +245,7 @@ async def websocket_endpoint(websocket: WebSocket):
             
             chat_history = parse_conversation_history(conversation_history, chat_history, user_message)
             
-            await websocket.send_text(fast_json_dumps({"answer": "This application is not yet ready to serve results. Please check back later.", "agent": None, "cart": persistent_cart}))
+            # await websocket.send_text(fast_json_dumps({"answer": "This application is not yet ready to serve results. Please check back later.", "agent": None, "cart": persistent_cart}))
 
             # # Single-agent example
             # try:
@@ -255,349 +255,350 @@ async def websocket_endpoint(websocket: WebSocket):
             #     logger.error("Error during single-agent response generation", exc_info=True)
             #     await websocket.send_text(fast_json_dumps({"answer": "Error during single-agent response generation", "error": str(e), "cart": persistent_cart}))
 
-            # # Multi-agent example with MCP inventory server and handoff service
-            # # Run customer loyalty task only once when session starts
-            # customer_id = "CUST001"
-            # if not customer_loyalty_executed:
-            #     asyncio.create_task(run_customer_loyalty_task(customer_id))
-            #     customer_loyalty_executed = True
-            # # Run handoff service
-            # try:
-            #     print("Entering handoff service.")
-            #     handoff_start_time = time.time()
-            #     formatted_history = format_chat_history(redact_bad_prompts_in_history(chat_history, bad_prompts))
-            #     logger.info("Handoff agent execution initiated - commencing agent selection protocol")
-            #     with tracer.start_as_current_span("Handoff Intent Classification"):
-            #         # Intent classification using structured outputs for reliable routing
-            #         intent_result = handoff_service.classify_intent(
-            #             user_message=user_message,
-            #             session_id=session_id,
-            #             chat_history=formatted_history
-            #         )
+            # Multi-agent example with MCP inventory server and handoff service
+            # Run customer loyalty task only once when session starts
+            customer_id = "CUST001"
+            if not customer_loyalty_executed:
+                asyncio.create_task(run_customer_loyalty_task(customer_id))
+                customer_loyalty_executed = True
+            # Run handoff service
+            try:
+                print("Entering handoff service.")
+                handoff_start_time = time.time()
+                formatted_history = format_chat_history(redact_bad_prompts_in_history(chat_history, bad_prompts))
+                logger.info("Handoff agent execution initiated - commencing agent selection protocol")
+                with tracer.start_as_current_span("Handoff Intent Classification"):
+                    # Intent classification using structured outputs for reliable routing
+                    intent_result = handoff_service.classify_intent(
+                        user_message=user_message,
+                        session_id=session_id,
+                        chat_history=formatted_history
+                    )
 
-            #     # Extract agent information from classification result
-            #     agent_name = intent_result["agent_id"]  # e.g., "cora", "cart_manager"
-            #     agent_selected = validated_env_vars.get(agent_name)  # Get agent ID from environment
+                # Extract agent information from classification result
+                agent_name = intent_result["agent_id"]  # e.g., "cora", "cart_manager"
+                agent_selected = validated_env_vars.get(agent_name)  # Get agent ID from environment
 
-            #     logger.info(f"Intent classification: domain={intent_result['domain']}, "
-            #                f"confidence={intent_result['confidence']:.2f}, "
-            #                f"reasoning={intent_result['reasoning']}")
-            #     print(f"Intent classification: domain={intent_result['domain']}, "
-            #                f"confidence={intent_result['confidence']:.2f}, "
-            #                f"reasoning={intent_result['reasoning']}")
-            #     log_timing("Handoff Processing", handoff_start_time, 
-            #               f"Selected: {agent_name} (confidence: {intent_result['confidence']:.2f})")
+                logger.info(f"Intent classification: domain={intent_result['domain']}, "
+                           f"confidence={intent_result['confidence']:.2f}, "
+                           f"reasoning={intent_result['reasoning']}")
+                print(f"Intent classification: domain={intent_result['domain']}, "
+                           f"confidence={intent_result['confidence']:.2f}, "
+                           f"reasoning={intent_result['reasoning']}")
+                log_timing("Handoff Processing", handoff_start_time, 
+                          f"Selected: {agent_name} (confidence: {intent_result['confidence']:.2f})")
                 
-            #     # Check if agent selection failed
-            #     if not agent_selected or not agent_name:
-            #         await websocket.send_text(fast_json_dumps({
-            #             "answer": "Sorry, I could not determine the right agent.",
-            #             "agent": None,
-            #             "cart": persistent_cart
-            #         }))
-            #         continue
-            # except Exception as e:
-            #     logger.error("Error during handoff classification", exc_info=True)
-            #     await websocket.send_text(fast_json_dumps({
-            #         "answer": "Error during handoff classification",
-            #         "error": str(e),
-            #         "cart": persistent_cart
-            #     }))
-            #     continue
+                # Check if agent selection failed
+                if not agent_selected or not agent_name:
+                    await websocket.send_text(fast_json_dumps({
+                        "answer": "Sorry, I could not determine the right agent.",
+                        "agent": None,
+                        "cart": persistent_cart
+                    }))
+                    continue
+            except Exception as e:
+                logger.error("Error during handoff classification", exc_info=True)
+                await websocket.send_text(fast_json_dumps({
+                    "answer": "Error during handoff classification",
+                    "error": str(e),
+                    "cart": persistent_cart
+                }))
+                continue
             
-            # # =============================================================================
-            # # UNIFIED AGENT EXECUTION: Context Enrichment & Agent Processing
-            # # =============================================================================
-            # # All agents follow a consistent execution pattern:
-            # # 1. Context Enrichment: Add multimodal data (images, products)
-            # # 2. Agent-Specific Preparation: Format context based on agent needs
-            # # 3. Agent Execution: Use AgentProcessor for streaming responses
-            # # 4. Response Handling: Parse output, update state, send to user
-            # # =============================================================================
-            # try:
-            #     agent_execution_start_time = time.time()
-            #     logger.info(f"{agent_name} agent execution initiated")
+            # =============================================================================
+            # UNIFIED AGENT EXECUTION: Context Enrichment & Agent Processing
+            # =============================================================================
+            # All agents follow a consistent execution pattern:
+            # 1. Context Enrichment: Add multimodal data (images, products)
+            # 2. Agent-Specific Preparation: Format context based on agent needs
+            # 3. Agent Execution: Use AgentProcessor for streaming responses
+            # 4. Response Handling: Parse output, update state, send to user
+            # =============================================================================
+            try:
+                agent_execution_start_time = time.time()
+                logger.info(f"{agent_name} agent execution initiated")
                 
-            #     # Initialize context enrichment variables
-            #     enriched_message = user_message  # Base message
-            #     image_data = None                # Image description from vision analysis
-            #     products = None                  # Product recommendations from AI Search
+                # Initialize context enrichment variables
+                enriched_message = user_message  # Base message
+                image_data = None                # Image description from vision analysis
+                products = None                  # Product recommendations from AI Search
                 
-            #     # =============================================================================
-            #     # MULTIMODAL CONTENT PROCESSING: Enrich context with visual data
-            #     # =============================================================================
-            #     # Process images to add visual understanding to the agent's context.
-            #     # This enables contextually aware recommendations based on what the user shares.
-            #     # =============================================================================
+                # =============================================================================
+                # MULTIMODAL CONTENT PROCESSING: Enrich context with visual data
+                # =============================================================================
+                # Process images to add visual understanding to the agent's context.
+                # This enables contextually aware recommendations based on what the user shares.
+                # =============================================================================
                 
-            #     # Process multimodal inputs if present
-            #     if image_url:
-            #         # IMAGE ANALYSIS: Extract visual information from uploaded images
-            #         # Uses phi-4 vision model with caching to avoid re-analyzing same image
-            #         # Results are cached for the session and shared across agents
-            #         image_start_time = time.time()
-            #         log_cache_status(image_cache, image_url)
-            #         image_data = await get_cached_image_description(image_url, image_cache)
-            #         log_timing("Image Analysis", image_start_time, f"URL: {image_url[:50]}...")
+                # Process multimodal inputs if present
+                if image_url:
+                    # IMAGE ANALYSIS: Extract visual information from uploaded images
+                    # Uses phi-4 vision model with caching to avoid re-analyzing same image
+                    # Results are cached for the session and shared across agents
+                    image_start_time = time.time()
+                    log_cache_status(image_cache, image_url)
+                    image_data = await get_cached_image_description(image_url, image_cache)
+                    log_timing("Image Analysis", image_start_time, f"URL: {image_url[:50]}...")
                     
-            #         # Send analysis message to user (provides feedback during processing)
-            #         analysis_msg = get_rotating_message(IMAGE_ANALYSIS_MESSAGES)
-            #         await websocket.send_text(fast_json_dumps({
-            #             "answer": analysis_msg,
-            #             "agent": agent_name,
-            #             "cart": persistent_cart
-            #         }))
-            #         logger.info("Image analysis completed")
+                    # Send analysis message to user (provides feedback during processing)
+                    analysis_msg = get_rotating_message(IMAGE_ANALYSIS_MESSAGES)
+                    await websocket.send_text(fast_json_dumps({
+                        "answer": analysis_msg,
+                        "agent": agent_name,
+                        "cart": persistent_cart
+                    }))
+                    logger.info("Image analysis completed")
                 
-            #     # =============================================================================
-            #     # PRODUCT RECOMMENDATIONS: AI Search integration for contextual products
-            #     # =============================================================================
-            #     # For agents that make product recommendations, query AI Search with enriched
-            #     # context (user message + visual analysis). This provides the agent with
-            #     # relevant product options to suggest based on user needs and visual context.
-            #     # =============================================================================
+                # =============================================================================
+                # PRODUCT RECOMMENDATIONS: AI Search integration for contextual products
+                # =============================================================================
+                # For agents that make product recommendations, query AI Search with enriched
+                # context (user message + visual analysis). This provides the agent with
+                # relevant product options to suggest based on user needs and visual context.
+                # =============================================================================
                 
-            #     # Get product recommendations for relevant agents
-            #     if agent_name in ["interior_designer", "interior_designer_create_image", "cora"]:
-            #         product_start_time = time.time()
-            #         # Build search query from all available context
-            #         search_query = user_message
-            #         if image_data:
-            #             # Add visual context to search (e.g., "blue living room" → search for blue paint)
-            #             search_query += f" {image_data} paint accessories, paint sprayers, drop cloths, painters tape"
+                # Get product recommendations for relevant agents
+                if agent_name in ["interior_designer", "interior_designer_create_image", "cora"]:
+                    product_start_time = time.time()
+                    # Build search query from all available context
+                    search_query = user_message
+                    if image_data:
+                        # Add visual context to search (e.g., "blue living room" → search for blue paint)
+                        search_query += f" {image_data} paint accessories, paint sprayers, drop cloths, painters tape"
                     
-            #         products = product_recommendations(search_query)
-            #         log_timing("Product Recommendations", product_start_time, f"Found: {len(products) if products else 0}")
-            #         logger.info("Product recommendations completed")
+                    products = product_recommendations(search_query)
+                    log_timing("Product Recommendations", product_start_time, f"Found: {len(products) if products else 0}")
+                    logger.info("Product recommendations completed")
                 
-            #     # =============================================================================
-            #     # CONTEXT ENRICHMENT: Build complete message with all available context
-            #     # =============================================================================
-            #     # Combine user message with multimodal analysis and product data to create
-            #     # a comprehensive context for the agent. This enables more accurate and
-            #     # contextually relevant responses.
-            #     # =============================================================================
+                # =============================================================================
+                # CONTEXT ENRICHMENT: Build complete message with all available context
+                # =============================================================================
+                # Combine user message with multimodal analysis and product data to create
+                # a comprehensive context for the agent. This enables more accurate and
+                # contextually relevant responses.
+                # =============================================================================
                 
-            #     # Build enriched message with all context
-            #     if image_data or products:
-            #         context_parts = []
-            #         if image_data:
-            #             context_parts.append(f"Image description: {image_data}")
-            #         if products:
-            #             context_parts.append(f"Available products: {fast_json_dumps(products)}")
+                # Build enriched message with all context
+                if image_data or products:
+                    context_parts = []
+                    if image_data:
+                        context_parts.append(f"Image description: {image_data}")
+                    if products:
+                        context_parts.append(f"Available products: {fast_json_dumps(products)}")
                     
-            #         # Prepend user message, append all enriched context
-            #         enriched_message = f"{user_message}\n\n" + "\n".join(context_parts)
+                    # Prepend user message, append all enriched context
+                    enriched_message = f"{user_message}\n\n" + "\n".join(context_parts)
                 
-            #     # =============================================================================
-            #     # AGENT EXECUTION: Unified pattern for all agents (no if-else branching!)
-            #     # =============================================================================
-            #     # All agents now follow the same execution flow:
-            #     # 1. Prepare agent-specific context (raw_io_history, conversation, enriched message)
-            #     # 2. Get or create AgentProcessor for the selected agent
-            #     # 3. Stream response chunks from the agent
-            #     # 4. Parse structured response and update session state
-            #     #
-            #     # SPECIAL CASE: interior_designer_create_image uses gpt-image-1 instead of agent
-            #     # =============================================================================
+                # =============================================================================
+                # AGENT EXECUTION: Unified pattern for all agents (no if-else branching!)
+                # =============================================================================
+                # All agents now follow the same execution flow:
+                # 1. Prepare agent-specific context (raw_io_history, conversation, enriched message)
+                # 2. Get or create AgentProcessor for the selected agent
+                # 3. Stream response chunks from the agent
+                # 4. Parse structured response and update session state
+                #
+                # SPECIAL CASE: interior_designer_create_image uses gpt-image-1 instead of agent
+                # =============================================================================
                 
-            #     # Execute agent based on type - unified agent processor pattern
-            #     bot_reply = ""
+                # Execute agent based on type - unified agent processor pattern
+                bot_reply = ""
                 
-            #     with tracer.start_as_current_span(f"{agent_name.title()} Agent Call"):
-            #         # =================================================================
-            #         # SPECIAL CASE: Image Creation (uses gpt-image-1, not agent processor)
-            #         # =================================================================
-            #         # This is the only case that doesn't use the unified agent pattern
-            #         # because it generates images via gpt-image-1 API rather than conversing
-            #         if agent_name == "interior_designer_create_image":
-            #             # Acknowledge image creation request
-            #             thank_you_msg = get_rotating_message(IMAGE_CREATE_MESSAGES)
-            #             await websocket.send_text(fast_json_dumps({
-            #                 "answer": thank_you_msg,
-            #                 "agent": "interior_designer",
-            #                 "cart": persistent_cart
-            #             }))
-                        
-            #             # Use persistent image URL for context (e.g., "make this room blue")
-            #             if persistent_image_url:
-            #                 image_data = await get_cached_image_description(persistent_image_url, image_cache)
-            #                 enriched_message = f"{user_message} {image_data}"
-                        
-            #             # Create image using gpt-image-1
-            #             image = create_image(text=enriched_message, image_url=persistent_image_url)
-                        
-            #             # Build response with generated image URL
-            #             response_data = {
-            #                 "answer": "Here is the requested image",
-            #                 "products": "",
-            #                 "discount_percentage": session_discount_percentage or "",
-            #                 "image_url": image,
-            #                 "additional_data": "",
-            #                 "cart": persistent_cart
-            #             }
-                        
-            #             # Send response
-            #             response_json = fast_json_dumps(response_data)
-            #             raw_io_history.append({"output": response_json, "cart": persistent_cart})
-                        
-            #             bot_answer = response_data.get("answer", "")
-            #             product_names = extract_product_names_from_response(response_data)
-            #             chat_history.append(("bot", bot_answer + product_names))
-                        
-            #             await websocket.send_text(response_json)
-            #             log_timing("Agent Execution", agent_execution_start_time, f"Agent: {agent_name}")
-            #             continue  # Skip common response handling
+                with tracer.start_as_current_span(f"{agent_name.title()} Agent Call"):
+                    # =================================================================
+                    # SPECIAL CASE: Image Creation (uses gpt-image-1, not agent processor)
+                    # =================================================================
+                    # This is the only case that doesn't use the unified agent pattern
+                    # because it generates images via gpt-image-1 API rather than conversing
+                    # COMMENTED OUT: Requires gpt-image-1 model (available upon request only)
+                    # if agent_name == "interior_designer_create_image":
+                    #     # Acknowledge image creation request
+                    #     thank_you_msg = get_rotating_message(IMAGE_CREATE_MESSAGES)
+                    #     await websocket.send_text(fast_json_dumps({
+                    #         "answer": thank_you_msg,
+                    #         "agent": "interior_designer",
+                    #         "cart": persistent_cart
+                    #     }))
+                    #     
+                    #     # Use persistent image URL for context (e.g., "make this room blue")
+                    #     if persistent_image_url:
+                    #         image_data = await get_cached_image_description(persistent_image_url, image_cache)
+                    #         enriched_message = f"{user_message} {image_data}"
+                    #     
+                    #     # Create image using gpt-image-1
+                    #     image = create_image(text=enriched_message, image_url=persistent_image_url)
+                    #     
+                    #     # Build response with generated image URL
+                    #     response_data = {
+                    #         "answer": "Here is the requested image",
+                    #         "products": "",
+                    #         "discount_percentage": session_discount_percentage or "",
+                    #         "image_url": image,
+                    #         "additional_data": "",
+                    #         "cart": persistent_cart
+                    #     }
+                    #     
+                    #     # Send response
+                    #     response_json = fast_json_dumps(response_data)
+                    #     raw_io_history.append({"output": response_json, "cart": persistent_cart})
+                    #     
+                    #     bot_answer = response_data.get("answer", "")
+                    #     product_names = extract_product_names_from_response(response_data)
+                    #     chat_history.append(("bot", bot_answer + product_names))
+                    #     
+                    #     await websocket.send_text(response_json)
+                    #     log_timing("Agent Execution", agent_execution_start_time, f"Agent: {agent_name}")
+                    #     continue  # Skip common response handling
                     
-            #         # =================================================================
-            #         # AGENT-SPECIFIC CONTEXT PREPARATION
-            #         # =================================================================
-            #         # Each agent type receives context tailored to its needs:
-            #         # - cart_manager: Full raw I/O history for tracking cart state changes
-            #         # - cora: Formatted conversation history for contextual responses
-            #         # - Others: Enriched message with multimodal + product data
-            #         # =================================================================
+                    # =================================================================
+                    # AGENT-SPECIFIC CONTEXT PREPARATION
+                    # =================================================================
+                    # Each agent type receives context tailored to its needs:
+                    # - cart_manager: Full raw I/O history for tracking cart state changes
+                    # - cora: Formatted conversation history for contextual responses
+                    # - Others: Enriched message with multimodal + product data
+                    # =================================================================
                     
-            #         # Prepare context based on agent type
-            #         agent_context = enriched_message  # Default: enriched message
+                    # Prepare context based on agent type
+                    agent_context = enriched_message  # Default: enriched message
                     
-            #         # Cart manager needs full raw_io_history for state management
-            #         if agent_name == "cart_manager":
-            #             # Provide complete interaction history so cart_manager can track
-            #             # all add/remove operations and maintain accurate cart state
-            #             agent_context = f"{enriched_message}\n\nRAW_IO_HISTORY:\n{fast_json_dumps(list(raw_io_history), option=orjson.OPT_INDENT_2)}"
+                    # Cart manager needs full raw_io_history for state management
+                    if agent_name == "cart_manager":
+                        # Provide complete interaction history so cart_manager can track
+                        # all add/remove operations and maintain accurate cart state
+                        agent_context = f"{enriched_message}\n\nRAW_IO_HISTORY:\n{fast_json_dumps(list(raw_io_history), option=orjson.OPT_INDENT_2)}"
                     
-            #         # Cora needs conversation history for contextual dialogue
-            #         elif agent_name == "cora":
-            #             # Provide formatted chat history so cora can reference previous
-            #             # conversation turns and maintain coherent multi-turn dialogue
-            #             agent_context = f"{formatted_history}\n\nUser: {enriched_message}"
+                    # Cora needs conversation history for contextual dialogue
+                    elif agent_name == "cora":
+                        # Provide formatted chat history so cora can reference previous
+                        # conversation turns and maintain coherent multi-turn dialogue
+                        agent_context = f"{formatted_history}\n\nUser: {enriched_message}"
                     
-            #         # =================================================================
-            #         # UNIFIED AGENT PROCESSOR EXECUTION (All agents use this pattern!)
-            #         # =================================================================
-            #         # Get or create an AgentProcessor instance for the selected agent.
-            #         # The processor manages the agent's execution lifecycle and streams
-            #         # responses back token-by-token for a better user experience.
-            #         #
-            #         # This replaces the old if-else branching with a single unified flow.
-            #         # =================================================================
+                    # =================================================================
+                    # UNIFIED AGENT PROCESSOR EXECUTION (All agents use this pattern!)
+                    # =================================================================
+                    # Get or create an AgentProcessor instance for the selected agent.
+                    # The processor manages the agent's execution lifecycle and streams
+                    # responses back token-by-token for a better user experience.
+                    #
+                    # This replaces the old if-else branching with a single unified flow.
+                    # =================================================================
                     
-            #         # All agents use unified agent processor pattern
-            #         processor = get_or_create_agent_processor(
-            #             agent_id=agent_selected,     # Agent ID from environment variables
-            #             agent_type=agent_name,       # Agent type (cora, cart_manager, etc.)
-            #             thread_id=thread.id,         # Conversation thread for stateful agents
-            #             project_client=project_client  # Azure AI client for agent execution
-            #         )
+                    # All agents use unified agent processor pattern
+                    processor = get_or_create_agent_processor(
+                        agent_id=agent_selected,     # Agent ID from environment variables
+                        agent_type=agent_name,       # Agent type (cora, cart_manager, etc.)
+                        thread_id=thread.id,         # Conversation thread for stateful agents
+                        project_client=project_client  # Azure AI client for agent execution
+                    )
                     
-            #         # Stream response from agent (yields chunks as they're generated)
-            #         async for msg in processor.run_conversation_with_text_stream(input_message=agent_context):
-            #             bot_reply = extract_bot_reply(msg)  # Extract text from streaming message
+                    # Stream response from agent (yields chunks as they're generated)
+                    async for msg in processor.run_conversation_with_text_stream(input_message=agent_context):
+                        bot_reply = extract_bot_reply(msg)  # Extract text from streaming message
                 
-            #     logger.info(f"{agent_name} agent execution completed")
+                logger.info(f"{agent_name} agent execution completed")
                 
-            #     log_timing("Agent Execution", agent_execution_start_time, f"Agent: {agent_name}")
+                log_timing("Agent Execution", agent_execution_start_time, f"Agent: {agent_name}")
                 
-            #     # =============================================================================
-            #     # RESPONSE PROCESSING: Parse structured output and update session state
-            #     # =============================================================================
-            #     # Agents return structured JSON responses with fields like answer, products,
-            #     # discount_percentage, image_url, etc. We parse this, update session state,
-            #     # and send formatted response to the user.
-            #     # =============================================================================
+                # =============================================================================
+                # RESPONSE PROCESSING: Parse structured output and update session state
+                # =============================================================================
+                # Agents return structured JSON responses with fields like answer, products,
+                # discount_percentage, image_url, etc. We parse this, update session state,
+                # and send formatted response to the user.
+                # =============================================================================
                 
-            #     # Parse the response first to get structured fields (answer, products, etc.)
-            #     parsed_response = parse_agent_response(bot_reply)
-            #     parsed_response["agent"] = agent_name  # Override agent field to show which agent responded
+                # Parse the response first to get structured fields (answer, products, etc.)
+                parsed_response = parse_agent_response(bot_reply)
+                parsed_response["agent"] = agent_name  # Override agent field to show which agent responded
                 
-            #     # =============================================================================
-            #     # CART STATE UPDATE: Persist cart changes from cart_manager agent
-            #     # =============================================================================
-            #     # The cart_manager agent returns an updated cart array in its response.
-            #     # We persist this to the session so all subsequent messages see the updated cart.
-            #     # =============================================================================
+                # =============================================================================
+                # CART STATE UPDATE: Persist cart changes from cart_manager agent
+                # =============================================================================
+                # The cart_manager agent returns an updated cart array in its response.
+                # We persist this to the session so all subsequent messages see the updated cart.
+                # =============================================================================
                 
-            #     # Update persistent_cart if cart_manager returned a cart
-            #     if agent_name == "cart_manager" and "cart" in parsed_response:
-            #         if isinstance(parsed_response.get("cart"), list):
-            #             persistent_cart = parsed_response["cart"]
-            #             logger.info(f"Cart updated by cart_manager: {len(persistent_cart)} items")
+                # Update persistent_cart if cart_manager returned a cart
+                if agent_name == "cart_manager" and "cart" in parsed_response:
+                    if isinstance(parsed_response.get("cart"), list):
+                        persistent_cart = parsed_response["cart"]
+                        logger.info(f"Cart updated by cart_manager: {len(persistent_cart)} items")
                 
-            #     # =============================================================================
-            #     # CONVERSATION HISTORY UPDATE: Maintain chat context for multi-turn dialogue
-            #     # =============================================================================
-            #     # Add the bot's response to chat history so future messages have context.
-            #     # Clean the history to remove large product data (keep only product names).
-            #     # =============================================================================
+                # =============================================================================
+                # CONVERSATION HISTORY UPDATE: Maintain chat context for multi-turn dialogue
+                # =============================================================================
+                # Add the bot's response to chat history so future messages have context.
+                # Clean the history to remove large product data (keep only product names).
+                # =============================================================================
                 
-            #     # Add the bot reply to chat history with products if available
-            #     bot_answer = parsed_response.get("answer", bot_reply or "")
-            #     product_names = extract_product_names_from_response(parsed_response)
-            #     chat_history.append(("bot", bot_answer + product_names))
-            #     print(f"Chat history after bot reply: {chat_history}")
+                # Add the bot reply to chat history with products if available
+                bot_answer = parsed_response.get("answer", bot_reply or "")
+                product_names = extract_product_names_from_response(parsed_response)
+                chat_history.append(("bot", bot_answer + product_names))
+                print(f"Chat history after bot reply: {chat_history}")
                 
-            #     # Clean the conversation history to remove large product data (keep compact)
-            #     chat_history = clean_conversation_history(chat_history)
-            #     print(f"Chat history after bot reply: {chat_history}")
+                # Clean the conversation history to remove large product data (keep compact)
+                chat_history = clean_conversation_history(chat_history)
+                print(f"Chat history after bot reply: {chat_history}")
                 
-            #     # =============================================================================
-            #     # DISCOUNT PERSISTENCE: Maintain customer loyalty tier across session
-            #     # =============================================================================
-            #     # Once the customer_loyalty agent calculates a discount, persist it across
-            #     # all subsequent responses so the user sees consistent discount information.
-            #     # =============================================================================
+                # =============================================================================
+                # DISCOUNT PERSISTENCE: Maintain customer loyalty tier across session
+                # =============================================================================
+                # Once the customer_loyalty agent calculates a discount, persist it across
+                # all subsequent responses so the user sees consistent discount information.
+                # =============================================================================
                 
-            #     # Update session discount_percentage if a new one is received
-            #     if parsed_response.get("discount_percentage"):
-            #         session_discount_percentage = parsed_response["discount_percentage"]
+                # Update session discount_percentage if a new one is received
+                if parsed_response.get("discount_percentage"):
+                    session_discount_percentage = parsed_response["discount_percentage"]
                 
-            #     # Include session discount_percentage in all responses if available
-            #     if session_discount_percentage and not parsed_response.get("discount_percentage"):
-            #         parsed_response["discount_percentage"] = session_discount_percentage
+                # Include session discount_percentage in all responses if available
+                if session_discount_percentage and not parsed_response.get("discount_percentage"):
+                    parsed_response["discount_percentage"] = session_discount_percentage
                 
-            #     # =============================================================================
-            #     # RESPONSE TRANSMISSION: Send structured response to user
-            #     # =============================================================================
-            #     # Send the final response with all fields (answer, products, cart, discount, etc.)
-            #     # Also append to raw_io_history for cart_manager's state tracking.
-            #     # =============================================================================
+                # =============================================================================
+                # RESPONSE TRANSMISSION: Send structured response to user
+                # =============================================================================
+                # Send the final response with all fields (answer, products, cart, discount, etc.)
+                # Also append to raw_io_history for cart_manager's state tracking.
+                # =============================================================================
                 
-            #     # When sending any other response, also append to raw_io_history
-            #     response_json = fast_json_dumps({**parsed_response, "cart": persistent_cart})
-            #     raw_io_history.append({"output": response_json, "cart": persistent_cart})
-            #     await websocket.send_text(response_json)
+                # When sending any other response, also append to raw_io_history
+                response_json = fast_json_dumps({**parsed_response, "cart": persistent_cart})
+                raw_io_history.append({"output": response_json, "cart": persistent_cart})
+                await websocket.send_text(response_json)
                 
-            #     # =============================================================================
-            #     # DELAYED LOYALTY RESPONSE: Send loyalty message after cart operations
-            #     # =============================================================================
-            #     # The customer_loyalty agent runs in background at session start.
-            #     # Its response is delayed until after the first cart_manager operation,
-            #     # ensuring users see their loyalty tier after interacting with the cart.
-            #     # =============================================================================
+                # =============================================================================
+                # DELAYED LOYALTY RESPONSE: Send loyalty message after cart operations
+                # =============================================================================
+                # The customer_loyalty agent runs in background at session start.
+                # Its response is delayed until after the first cart_manager operation,
+                # ensuring users see their loyalty tier after interacting with the cart.
+                # =============================================================================
                 
-            #     # After cart_manager response, send loyalty response if available (only once per session)
-            #     if agent_name == "cart_manager" and session_loyalty_response and not loyalty_response_sent:
-            #         loyalty_response_with_cart = {**session_loyalty_response, "cart": persistent_cart}
-            #         await websocket.send_text(fast_json_dumps(loyalty_response_with_cart))
-            #         loyalty_response_sent = True
+                # After cart_manager response, send loyalty response if available (only once per session)
+                if agent_name == "cart_manager" and session_loyalty_response and not loyalty_response_sent:
+                    loyalty_response_with_cart = {**session_loyalty_response, "cart": persistent_cart}
+                    await websocket.send_text(fast_json_dumps(loyalty_response_with_cart))
+                    loyalty_response_sent = True
                     
-            # # =============================================================================
-            # # ERROR HANDLING: Failure during agent execution
-            # # =============================================================================
-            # # If agent execution fails, catch the exception, log it for debugging,
-            # # and send a user-friendly error message with the current cart state.
-            # # =============================================================================
-            # except Exception as e:
-            #     logger.error("Error in agent execution", exc_info=True)
-            #     try:
-            #         await websocket.send_text(fast_json_dumps({
-            #             "answer": "Internal server error",
-            #             "error": str(e),
-            #             "cart": persistent_cart
-            #         }))
-            #     except Exception:
-            #         pass  # If even error sending fails, silently continue
+            # =============================================================================
+            # ERROR HANDLING: Failure during agent execution
+            # =============================================================================
+            # If agent execution fails, catch the exception, log it for debugging,
+            # and send a user-friendly error message with the current cart state.
+            # =============================================================================
+            except Exception as e:
+                logger.error("Error in agent execution", exc_info=True)
+                try:
+                    await websocket.send_text(fast_json_dumps({
+                        "answer": "Internal server error",
+                        "error": str(e),
+                        "cart": persistent_cart
+                    }))
+                except Exception:
+                    pass  # If even error sending fails, silently continue
     
     # =============================================================================
     # SESSION-LEVEL ERROR HANDLING: Catch WebSocket disconnects and errors

--- a/src/infra/DeployAzureResources.bicep
+++ b/src/infra/DeployAzureResources.bicep
@@ -15,7 +15,7 @@ var webAppName = '${uniqueString(resourceGroup().id)}-app'
 var appServicePlanName = '${uniqueString(resourceGroup().id)}-cosu-asp'
 var logAnalyticsName = '${uniqueString(resourceGroup().id)}-cosu-la'
 var appInsightsName = '${uniqueString(resourceGroup().id)}-cosu-ai'
-var webAppSku = 'S1'
+// var webAppSku = 'P1v4'
 var registryName = '${uniqueString(resourceGroup().id)}cosureg'
 var registrySku = 'Standard'
 
@@ -152,57 +152,57 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2022-12-01' =
   }
 }
 
-@description('Creates an Azure App Service Plan.')
-resource appServicePlan 'Microsoft.Web/serverFarms@2022-09-01' = {
-  name: appServicePlanName
-  location: location
-  kind: 'linux'
-  properties: {
-    reserved: true
-  }
-  sku: {
-    name: webAppSku
-  }
-}
+// @description('Creates an Azure App Service Plan.')
+// resource appServicePlan 'Microsoft.Web/serverFarms@2022-09-01' = {
+//   name: appServicePlanName
+//   location: location
+//   kind: 'linux'
+//   properties: {
+//     reserved: true
+//   }
+//   sku: {
+//     name: webAppSku
+//   }
+// }
 
-@description('Creates an Azure App Service for Zava.')
-resource appServiceApp 'Microsoft.Web/sites@2022-09-01' = {
-  name: webAppName
-  location: location
-  properties: {
-    serverFarmId: appServicePlan.id
-    httpsOnly: true
-    clientAffinityEnabled: false
-    siteConfig: {
-      linuxFxVersion: 'DOCKER|${containerRegistry.name}.azurecr.io/${uniqueString(resourceGroup().id)}/techworkshopl300/zava'
-      http20Enabled: true
-      minTlsVersion: '1.2'
-      appCommandLine: ''
-      appSettings: [
-        {
-          name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
-          value: 'false'
-        }
-        {
-          name: 'DOCKER_REGISTRY_SERVER_URL'
-          value: 'https://${containerRegistry.name}.azurecr.io'
-        }
-        {
-          name: 'DOCKER_REGISTRY_SERVER_USERNAME'
-          value: containerRegistry.name
-        }
-        {
-          name: 'DOCKER_REGISTRY_SERVER_PASSWORD'
-          value: containerRegistry.listCredentials().passwords[0].value
-        }
-        {
-          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-          value: appInsights.properties.InstrumentationKey
-        }
-        ]
-      }
-    }
-}
+// @description('Creates an Azure App Service for Zava.')
+// resource appServiceApp 'Microsoft.Web/sites@2022-09-01' = {
+//   name: webAppName
+//   location: location
+//   properties: {
+//     serverFarmId: appServicePlan.id
+//     httpsOnly: true
+//     clientAffinityEnabled: false
+//     siteConfig: {
+//       linuxFxVersion: 'DOCKER|${containerRegistry.name}.azurecr.io/${uniqueString(resourceGroup().id)}/techworkshopl300/zava'
+//       http20Enabled: true
+//       minTlsVersion: '1.2'
+//       appCommandLine: ''
+//       appSettings: [
+//         {
+//           name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
+//           value: 'false'
+//         }
+//         {
+//           name: 'DOCKER_REGISTRY_SERVER_URL'
+//           value: 'https://${containerRegistry.name}.azurecr.io'
+//         }
+//         {
+//           name: 'DOCKER_REGISTRY_SERVER_USERNAME'
+//           value: containerRegistry.name
+//         }
+//         {
+//           name: 'DOCKER_REGISTRY_SERVER_PASSWORD'
+//           value: containerRegistry.listCredentials().passwords[0].value
+//         }
+//         {
+//           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+//           value: appInsights.properties.InstrumentationKey
+//         }
+//         ]
+//       }
+//     }
+// }
 
 // Cosmos DB built-in data plane role IDs
 // Reference: https://learn.microsoft.com/en-us/connectors/documentdb/#microsoft-entra-id-authentication-and-cosmos-db-connector
@@ -298,6 +298,6 @@ output cosmosDbEndpoint string = cosmosDbAccount.properties.documentEndpoint
 output storageAccountName string = storageAccount.name
 output searchServiceName string = searchService.name
 output container_registry_name string = containerRegistry.name
-output application_name string = appServiceApp.name
-output application_url string = appServiceApp.properties.hostNames[0]
+// output application_name string = appServiceApp.name
+// output application_url string = appServiceApp.properties.hostNames[0]
 

--- a/src/infra/DeployAzureResources.json
+++ b/src/infra/DeployAzureResources.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.39.26.7824",
+      "templateHash": "16854380566239867042"
+    }
+  },
+  "parameters": {
+    "userPrincipalId": {
+      "type": "string",
+      "metadata": {
+        "description": "Object ID of the user/principal to grant Cosmos DB data access"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "minLength": 1,
+      "metadata": {
+        "description": "Primary location for all resources."
+      }
+    }
+  },
+  "variables": {
+    "cosmosDbName": "[format('{0}-cosmosdb', uniqueString(resourceGroup().id))]",
+    "cosmosDbDatabaseName": "zava",
+    "storageAccountName": "[format('{0}sa', uniqueString(resourceGroup().id))]",
+    "aiFoundryName": "[format('aif-{0}', uniqueString(resourceGroup().id))]",
+    "aiProjectName": "[format('proj-{0}', uniqueString(resourceGroup().id))]",
+    "searchServiceName": "[format('{0}-search', uniqueString(resourceGroup().id))]",
+    "webAppName": "[format('{0}-app', uniqueString(resourceGroup().id))]",
+    "appServicePlanName": "[format('{0}-cosu-asp', uniqueString(resourceGroup().id))]",
+    "logAnalyticsName": "[format('{0}-cosu-la', uniqueString(resourceGroup().id))]",
+    "appInsightsName": "[format('{0}-cosu-ai', uniqueString(resourceGroup().id))]",
+    "webAppSku": "B1",
+    "registryName": "[format('{0}cosureg', uniqueString(resourceGroup().id))]",
+    "registrySku": "Standard",
+    "locations": [
+      {
+        "locationName": "[parameters('location')]",
+        "failoverPriority": 0,
+        "isZoneRedundant": false
+      }
+    ],
+    "cosmosDbBuiltInDataReaderRoleId": "00000000-0000-0000-0000-000000000001",
+    "cosmosDbBuiltInDataContributorRoleId": "00000000-0000-0000-0000-000000000002",
+    "cosmosDbAccountReaderRoleId": "fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
+    "cognitiveServicesOpenAIUserRoleId": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+    "cognitiveServicesContributorRoleId": "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts",
+      "apiVersion": "2023-04-15",
+      "name": "[variables('cosmosDbName')]",
+      "location": "[parameters('location')]",
+      "kind": "GlobalDocumentDB",
+      "properties": {
+        "consistencyPolicy": {
+          "defaultConsistencyLevel": "Session"
+        },
+        "databaseAccountOfferType": "Standard",
+        "locations": "[variables('locations')]",
+        "disableLocalAuth": false
+      },
+      "metadata": {
+        "description": "Creates an Azure Cosmos DB NoSQL account."
+      }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+      "apiVersion": "2023-04-15",
+      "name": "[format('{0}/{1}', variables('cosmosDbName'), variables('cosmosDbDatabaseName'))]",
+      "properties": {
+        "resource": {
+          "id": "[variables('cosmosDbDatabaseName')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]"
+      ],
+      "metadata": {
+        "description": "Creates an Azure Cosmos DB NoSQL API database."
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot"
+      },
+      "metadata": {
+        "description": "Creates an Azure Storage account."
+      }
+    },
+    {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "apiVersion": "2025-04-01-preview",
+      "name": "[variables('aiFoundryName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "S0"
+      },
+      "kind": "AIServices",
+      "properties": {
+        "allowProjectManagement": true,
+        "customSubDomainName": "[variables('aiFoundryName')]",
+        "disableLocalAuth": false
+      }
+    },
+    {
+      "type": "Microsoft.CognitiveServices/accounts/projects",
+      "apiVersion": "2025-04-01-preview",
+      "name": "[format('{0}/{1}', variables('aiFoundryName'), variables('aiProjectName'))]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {},
+      "dependsOn": [
+        "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiFoundryName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Search/searchServices",
+      "apiVersion": "2023-11-01",
+      "name": "[variables('searchServiceName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "standard"
+      },
+      "metadata": {
+        "description": "Creates an Azure AI Search service."
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2023-09-01",
+      "name": "[variables('logAnalyticsName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 90,
+        "workspaceCapping": {
+          "dailyQuotaGb": 1
+        }
+      },
+      "metadata": {
+        "description": "Creates an Azure Log Analytics workspace."
+      }
+    },
+    {
+      "type": "Microsoft.Insights/components",
+      "apiVersion": "2020-02-02-preview",
+      "name": "[variables('appInsightsName')]",
+      "location": "[parameters('location')]",
+      "kind": "web",
+      "properties": {
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
+      ],
+      "metadata": {
+        "description": "Creates an Azure Application Insights resource."
+      }
+    },
+    {
+      "type": "Microsoft.ContainerRegistry/registries",
+      "apiVersion": "2022-12-01",
+      "name": "[variables('registryName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[variables('registrySku')]"
+      },
+      "properties": {
+        "adminUserEnabled": true
+      },
+      "metadata": {
+        "description": "Creates an Azure Container Registry."
+      }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+      "apiVersion": "2023-04-15",
+      "name": "[format('{0}/{1}', variables('cosmosDbName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), parameters('userPrincipalId'), variables('cosmosDbBuiltInDataContributorRoleId')))]",
+      "properties": {
+        "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), variables('cosmosDbBuiltInDataContributorRoleId'))]",
+        "principalId": "[parameters('userPrincipalId')]",
+        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cosmos DB Built-in Data Contributor role to the specified user"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[format('Microsoft.DocumentDB/databaseAccounts/{0}', variables('cosmosDbName'))]",
+      "name": "[guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cosmosDbAccountReaderRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cosmosDbAccountReaderRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cosmos DB Account Reader Role to AI Search"
+      }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+      "apiVersion": "2023-04-15",
+      "name": "[format('{0}/{1}', variables('cosmosDbName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cosmosDbBuiltInDataReaderRoleId')))]",
+      "properties": {
+        "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), variables('cosmosDbBuiltInDataReaderRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cosmos DB Built-in Data Reader role to AI Search"
+      }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+      "apiVersion": "2023-04-15",
+      "name": "[format('{0}/{1}', variables('cosmosDbName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cosmosDbBuiltInDataContributorRoleId')))]",
+      "properties": {
+        "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), variables('cosmosDbBuiltInDataContributorRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cosmos DB Built-in Data Contributor role to AI Search"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('aiFoundryName'), variables('aiProjectName'))]",
+      "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiFoundryName'), variables('aiProjectName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cognitiveServicesOpenAIUserRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesOpenAIUserRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiFoundryName'), variables('aiProjectName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cognitive Services OpenAI User role to AI Search on AI Project"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', variables('aiFoundryName'))]",
+      "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', variables('aiFoundryName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cognitiveServicesOpenAIUserRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesOpenAIUserRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiFoundryName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cognitive Services OpenAI User role to AI Search on AI Foundry"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}/projects/{1}', variables('aiFoundryName'), variables('aiProjectName'))]",
+      "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiFoundryName'), variables('aiProjectName')), resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('cognitiveServicesContributorRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesContributorRoleId'))]",
+        "principalId": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), '2023-11-01', 'full').identity.principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiFoundryName'), variables('aiProjectName'))]",
+        "[resourceId('Microsoft.Search/searchServices', variables('searchServiceName'))]"
+      ],
+      "metadata": {
+        "description": "Assigns Cognitive Services Contributor role to AI Search on AI Project"
+      }
+    }
+  ],
+  "outputs": {
+    "cosmosDbEndpoint": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbName')), '2023-04-15').documentEndpoint]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    },
+    "searchServiceName": {
+      "type": "string",
+      "value": "[variables('searchServiceName')]"
+    },
+    "container_registry_name": {
+      "type": "string",
+      "value": "[variables('registryName')]"
+    }
+  }
+}

--- a/src/prompts/CartManagerPrompt.txt
+++ b/src/prompts/CartManagerPrompt.txt
@@ -1,0 +1,85 @@
+You are a Cart Manager Assistant for Zava, a home improvement and furniture retailer.
+
+Your primary responsibilities:
+
+1. CART MANAGEMENT
+   - Add products to the customer's shopping cart
+   - Remove products from the cart
+   - Update product quantities
+   - Clear the entire cart when requested
+   - Provide cart summaries and totals
+
+2. CART OPERATIONS
+   When a customer mentions "cart", "add to cart", "remove", "checkout", or similar:
+   - Parse their request to understand what products they want to add/remove
+   - Update the cart state accordingly
+   - Confirm the action taken
+   - Show the updated cart contents
+
+3. CART STATE MANAGEMENT
+   You will receive:
+   - RAW_IO_HISTORY: Complete conversation and cart state history
+   - Current cart state
+   - Customer's latest request
+
+   You must return:
+   - Updated cart as a JSON array
+   - Conversational confirmation message
+   - Any relevant product recommendations
+
+4. PRODUCT RECOMMENDATIONS
+   Based on cart contents, suggest:
+   - Complementary products (e.g., if they added paint, suggest brushes, tape, drop cloths)
+   - Related items frequently bought together
+   - Products that complete a project
+
+5. RESPONSE FORMAT
+   Always respond in valid JSON format:
+   {
+       "answer": "Friendly confirmation message about what was added/removed",
+       "cart": [
+           {
+               "product_id": "PROD-123",
+               "name": "Product Name",
+               "quantity": 2,
+               "price": 29.99,
+               "total": 59.98
+           }
+       ],
+       "products": "Optional: Suggest related products here",
+       "discount_percentage": "",
+       "additional_data": ""
+   }
+
+6. CONVERSATION STYLE
+   - Be friendly and helpful
+   - Confirm actions clearly ("I've added 2 gallons of paint to your cart")
+   - Provide cart summaries when asked
+   - Suggest next steps ("Would you like to proceed to checkout?")
+   - If unclear, ask for clarification
+
+7. SPECIAL INSTRUCTIONS
+   - If customer asks about cart but it's empty, acknowledge and suggest browsing products
+   - If removing items, confirm which items were removed
+   - If updating quantities, confirm the new quantity
+   - Always maintain accurate cart state based on conversation history
+   - Extract product information from the conversation context
+   - On checkout, display the cart contents and tell the customer that they may pick up their products from the closest Zava retail outlet, located in Miami, Florida. Only give this information when the customer requests to check out.
+
+Example interactions:
+
+Customer: "Add the blue paint to my cart"
+Response: {
+    "answer": "I've added the blue paint to your cart! Would you also like to add paint brushes or painter's tape?",
+    "cart": [{"product_id": "PAINT-BLUE-001", "name": "Blue Interior Paint", "quantity": 1, "price": 34.99, "total": 34.99}],
+    "products": "Based on your paint selection, you might also need: Paint Brushes ($8.99), Painter's Tape ($5.99), Drop Cloth ($12.99)"
+}
+
+Customer: "What's in my cart?"
+Response: {
+    "answer": "You currently have 1 item in your cart: Blue Interior Paint (1 gallon) for $34.99. Your cart total is $34.99.",
+    "cart": [{"product_id": "PAINT-BLUE-001", "name": "Blue Interior Paint", "quantity": 1, "price": 34.99, "total": 34.99}],
+    "products": ""
+}
+
+Remember: Your goal is to make cart management seamless and helpful for customers!

--- a/src/prompts/CustomerLoyaltyAgentPrompt.txt
+++ b/src/prompts/CustomerLoyaltyAgentPrompt.txt
@@ -1,0 +1,22 @@
+Customer Loyalty Agent Guidelines
+========================================
+- Your task is assign discounts based on customers Loyalty information.Return the discount calculate from the calculate_discount tool as response.
+- Check Customer ID in query when asked about discount, if not ask customer ID.
+- Send CustomerID as input to calculate_discount tool to calculate discount
+- Write the response from tool in 1st person i.e (Congratulations! You are eligible for.. thankyou..) bla bla
+- Always include smile emojis like 🎉, 😊, or 🛍️ to keep the tone light and celebratory.
+- Example message(keep changing) : Hey there, Bruno! 🎉 \n Great news—you just scored an exclusive 20% off your order! \nTreat yourself and enjoy your special savings at checkout. Thanks for being awesome! 🙌
+- In your answer do not mention e.g. word instead use Example, such as or like based on the sentence.
+
+- Return response in following json format
+
+answer: your answer,
+discount_percentage:keep discount percentage from the tool.
+
+Customer Loyalty Agent Tool
+-----
+calculate_discount: Takes in customer id, calculates discount as per tier and returns response.
+
+Content Handling Guidelines
+---------------------------
+- Do not generate content summaries or remove any data.

--- a/src/prompts/InteriorDesignAgentPrompt.txt
+++ b/src/prompts/InteriorDesignAgentPrompt.txt
@@ -1,0 +1,55 @@
+Interior Design Agent Guidelines
+========================================
+- You are a Interior Designer sales person working for Zava and help customers who need help in DIY Projects and other interior design queries
+- Your main tasks are the following: recommending and upselling products, creating images
+- You will get input in the form of a json, having:
+[
+    {
+        "Conversation_history":the Conversation thats going on,
+        "image_url": Image based on which you need to recreate some image
+        "image_description": If there is an image attached, the description or it will be empty
+        "products_available": A list of products, from where you can give recommendations
+        "user_last_query": The last query from user
+    }
+]
+- You will always recommend product from the products_available.
+- You will keep asking questions to the user and keep recommending.
+- When you get an image, reply saying "I see you uploaded..."
+- If asked to change/modify/style an object, only then use create_image, otherwise keep recommending and upselling as usual.
+- In your answer do not mention e.g. word instead use Example, such as or like based on the sentence.
+
+Return response in following json format
+
+answer: your answer,
+image_output: if there, otherwise empty
+products: [
+  {
+    "id": "<ProductID>",
+    "name": "<ProductName>",
+    "type": "<Singular Category Name>",
+    "description": "<ProductDescription>",
+    "imageURL": "<ImageURL>",
+    "punchLine": "<ProductPunchLine>",
+    "price": "<FormattedPriceWithDollarSign>"
+  }, {..}
+  ...
+]
+
+
+Interior Design Agent Tool
+========================================
+create_image: Can create image as per users requirement such as repainting a given room in a different color (make sure the path and prompt is shared as is) given a prompt and path.
+
+Example Conversation
+========================================
+User: Want paint recommendation for my living room
+You: Give some paints options, ask dimension, ask image
+User: Gives dimensions, image (maybe)
+You: Recommends based on the color, calculate how much paint maybe required, upsell for sprayer, tape (saying its good)
+
+Content Handling Guidelines
+========================================
+- Do not generate content summaries or remove any data.
+
+---
+IMPORTANT: Your entire response must be a valid JSON array as described above. Do not include any other text or formatting.

--- a/src/prompts/InventoryAgentPrompt.txt
+++ b/src/prompts/InventoryAgentPrompt.txt
@@ -1,0 +1,15 @@
+Inventory Agent Guidelines
+========================================
+- Your task is check the inventory status
+- When user ask to check the inventory for product, send the product name to inventory_check tool.
+- Return response like inventory levels and status of inventory and the location.
+
+Inventory Agent Tool
+-----
+inventory_check: Takes in product dictionary, return inventory level.
+input formatting:
+product_dict = {'Standard Paint Tray': 'PROD0045', 'Other Product': 'PROD1234'}
+
+Content Handling Guidelines
+---------------------------
+- Do not generate content summaries or remove any data.

--- a/src/prompts/ShopperAgentPrompt.txt
+++ b/src/prompts/ShopperAgentPrompt.txt
@@ -1,0 +1,17 @@
+Shopper Agent Guidelines
+========================================
+- You are the public facing assistant of Zava
+- Greet people and help them as needed
+- Return response in following json format (image_output and products empty)
+
+answer: your answer,
+image_output: []
+products: []
+
+
+Shopper Agent Tool
+-----
+
+Content Handling Guidelines
+---------------------------
+- Do not generate content summaries or remove any data.


### PR DESCRIPTION
- Add 5 agent initializers (customer loyalty, inventory, interior design, shopper, cart manager)
- Add 5 agent prompts with specialized instructions and JSON response formats
- Create single-agent example for learning purposes
- Enable multi-agent mode in chat_app.py with handoff service
- Comment out image creation code (requires gpt-image-1 model)
- Comment out App Service deployment in Bicep (VM quota issues)
- Update INDEX_NAME to use actual search index